### PR TITLE
Remove usage of codecov ATS

### DIFF
--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Run tests and collect coverage
         run: pytest --cov=./ --cov-report=xml
 
-      - name: Run ATS
-        uses: codecov/codecov-ats@v0
-
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.5.0
         with:


### PR DESCRIPTION
We are in the process of deprecating the ATS feature of codecov, and I saw you are one of the few (open source) users of it.