### PR TITLE
Fix typos and logging test

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -999,7 +999,7 @@ For the complete list of features, please refer to the [API Documentation](https
   | |___test_cli_console.py
   | |___test_desc_limit.py
   | |___test_dl.py
-  | |___test_excetions.py
+  | |___test_exceptions.py
   | |___test_gzip.py
   | |___test_i18n.py
   | |___test_json_filter.py

--- a/README.md
+++ b/README.md
@@ -999,7 +999,7 @@
   | |___test_cli_console.py
   | |___test_desc_limit.py
   | |___test_dl.py
-  | |___test_excetions.py
+  | |___test_exceptions.py
   | |___test_gzip.py
   | |___test_i18n.py
   | |___test_json_filter.py

--- a/f2/utils/http/utils.py
+++ b/f2/utils/http/utils.py
@@ -29,7 +29,7 @@ async def get_content_length(
         int: Content-Length的值，如果获取失败则返回0 (Value of Content-Length, or 0 if retrieval fails)
     """
 
-    if proxies is ... or proxies is None:
+    if proxies is None:
         proxies = {"all://": None}
 
     proxy_url = (

--- a/f2/utils/time/filter.py
+++ b/f2/utils/time/filter.py
@@ -10,7 +10,7 @@ from f2.log.logger import logger
 async def filter_by_date_interval(
     data: Union[List[Dict], Dict],
     interval: str,
-    fied_name: str = "create_time",
+    field_name: str = "create_time",
 ) -> Union[List[Dict], Dict, None]:
     """
     筛选指定日期区间内的作品
@@ -18,14 +18,14 @@ async def filter_by_date_interval(
     Args:
         data (Union[List[Dict], Dict]): 作品列表或单个作品
         interval (str): 日期区间，格式：2022-01-01|2023-01-01
-        fied_name (str): 日期字段名称，默认为"create_time"
+        field_name (str): 日期字段名称，默认为"create_time"
 
     Returns:
         filtered_data (Union[List[Dict], Dict, None]): 筛选后的作品列表或单个作品
     """
 
     def is_within_interval(item: Dict) -> bool:
-        date_str = item.get(fied_name)
+        date_str = item.get(field_name)
         if not date_str:
             logger.warning(_("作品缺少创建时间：{0}").format(item))
             return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ keywords = [
     "websockets",
     "crawler",
     "downloader",
-    "internat",
+    "internet",
     "download",
     "f2",
     "http",

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,4 @@
-# path: tests/test_excetions.py
+# path: tests/test_exceptions.py
 
 import pytest
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -41,6 +41,10 @@ def test_log_file_creation(log_manager):
     log_files = list(temp_log_dir.glob("*.log"))
     assert len(log_files) == 1
 
+    # 验证日志文件内容非空且包含预期日志
+    log_text = log_files[0].read_text(encoding="utf-8")
+    assert "Test info message" in log_text
+
 
 def test_clean_logs(log_manager):
     manager, temp_log_dir = log_manager


### PR DESCRIPTION
## Summary
- fix `internet` typo in project metadata
- fix misuse of ellipsis in HTTP utilities
- rename `field_name` parameter in filter and update docs
- check file contents in logger test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'f2' and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68469c6c05f483259e2b9bdd56867518