### PR TITLE
Quality: Exception string is empty when filepath is absent

### DIFF
--- a/f2/exceptions/file_exceptions.py
+++ b/f2/exceptions/file_exceptions.py
@@ -14,7 +14,8 @@ class FileError(Exception):
 
     def __str__(self):
         """返回错误信息和文件路径（如果有的话）"""
-        return f"{super().__str__()} Filepath: {self.filepath}" if self.filepath else ""
+        msg = super().__str__()
+        return f"{msg} Filepath: {self.filepath}" if self.filepath else msg
 
 
 class FileNotFound(FileError):


### PR DESCRIPTION
## Problem

`FileError.__str__` returns an empty string if `self.filepath` is falsy, which hides the original exception message and makes debugging/logging significantly harder.

**Severity**: `high`
**File**: `f2/exceptions/file_exceptions.py`

## Solution

Always include the base exception message. Example: `msg = super().__str__(); return f"{msg} Filepath: {self.filepath}" if self.filepath else msg`.

## Changes

- `f2/exceptions/file_exceptions.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
