### PR TITLE
fix(weibo): capture all Set-Cookie headers in gen_visitor

### DIFF
--- a/f2/apps/weibo/utils.py
+++ b/f2/apps/weibo/utils.py
@@ -124,7 +124,10 @@ class VisitorManager(BaseCrawler):
             )
             response.raise_for_status()
 
-            visitor_cookie = split_set_cookie(response.headers.get("set-cookie", ""))
+            set_cookie_headers = response.headers.get_list("set-cookie")
+            visitor_cookie = ";".join(
+                c.split(";")[0] for c in set_cookie_headers if c
+            )
             return visitor_cookie
 
         except httpx.RequestError as exc:


### PR DESCRIPTION
Replace headers.get("set-cookie") with headers.get_list("set-cookie")
so all 20+ individual Set-Cookie headers from the genvisitor2 endpoint
are collected instead of only the first one.